### PR TITLE
Fixes return type error on docstring

### DIFF
--- a/src/NovaLinkResource.php
+++ b/src/NovaLinkResource.php
@@ -33,7 +33,7 @@ class NovaLinkResource extends Tool
     /**
      * Set the name link
      *
-     * @param  array  $name
+     * @param  string  $name
      *
      * @return array
      */
@@ -45,7 +45,7 @@ class NovaLinkResource extends Tool
     /**
      * Set the name link
      *
-     * @param  array  $name
+     * @param  string  $to
      *
      * @return array
      */
@@ -56,7 +56,6 @@ class NovaLinkResource extends Tool
 
     /**
      * @param string $icon
-     * @param string $type
      *
      * @return array
      */


### PR DESCRIPTION
In NovaLinkResource.php there were multiple occurrences where the return type is declared either wrong or had parameters which was never used in the method. This pull request intended to fix that. 